### PR TITLE
Fix spelling of several language names

### DIFF
--- a/golflang-list.md
+++ b/golflang-list.md
@@ -28,7 +28,7 @@ languages in this list are ordered from most relevant as of the latest commit to
 | fuzzy octo guacamole | [https://codereview.stackexchange.com/questions/124736/fuzzy-octo-guacamole-interpreter](https://codereview.stackexchange.com/questions/124736/fuzzy-octo-guacamole-interpreter) | Deleted, I think?
 | Micro | [https://esolangs.org/wiki/Micro](https://esolangs.org/wiki/Micro) | old and unmaintained
 | Milky-Way | [https://github.com/zachgates/Milky-Way](https://github.com/zachgates/Milky-Way)
-| ostrich-lang | [https://github.com/tckmn/ostrich-lang](https://github.com/tckmn/ostrich-lang)
+| Ostrich | [https://github.com/tckmn/ostrich-lang](https://github.com/tckmn/ostrich-lang)
 | Sclipting | [http://esolangs.org/wiki/Sclipting](http://esolangs.org/wiki/Sclipting) | no custom codepage?!
 | GolfLang | [https://github.com/PhiNotPi/GolfLang](https://github.com/PhiNotPi/GolfLang) | kinda not stack based?
 | Minkolang | [http://esolangs.org/wiki/Minkolang](http://esolangs.org/wiki/Minkolang) | elendia's thing
@@ -69,12 +69,12 @@ languages in this list are ordered from most relevant as of the latest commit to
 | Name | Link | comments
 |------|------|---------
 | Husk | [https://github.com/barbuz/Husk](https://github.com/barbuz/Husk) | infinite lists, combinators, very concise
-| pyth | [https://github.com/isaacg1/pyth](https://github.com/isaacg1/pyth) | python shortened, allows arbitrary python code
+| Pyth | [https://github.com/isaacg1/pyth](https://github.com/isaacg1/pyth) | python shortened, allows arbitrary python code
 | Charcoal | [https://github.com/somebody1234/Charcoal](https://github.com/somebody1234/Charcoal) | made with ascii art in mind, but very general purpose. mathematica connection
 | Arn | [https://github.com/ZippyMagician/Arn](https://github.com/ZippyMagician/Arn) | created in 2020, similar to J
-| minipyth | https://github.com/isaacg1/minipyth | minimalist pyth with only lowercase letter commands
-| hbl | https://github.com/dloscutoff/hbl/ | 2021, lisp style language based on Dlosc's Thimble
-| nibbles | https://nibbles.golf/ | 2021, new prefix bit based golfing language, pure ascii, currently in beta.
+| Minipyth | https://github.com/isaacg1/minipyth | minimalist pyth with only lowercase letter commands
+| HBL | https://github.com/dloscutoff/hbl/ | 2021, lisp style language based on Dlosc's Thimble
+| Nibbles | https://nibbles.golf/ | 2021, new prefix bit based golfing language, pure ascii, currently in beta.
 | Sledgehammer | [https://github.com/tkwa/Sledgehammer](https://github.com/tkwa/Sledgehammer) | even smaller mathematica
 | Java-Golf | [https://github.com/GamrCorps/Java-Golf](https://github.com/GamrCorps/Java-Golf)
 | Jolf | [https://github.com/ConorOBrien-Foxx/Jolf/](https://github.com/ConorOBrien-Foxx/Jolf/) | Very short, underused and has graphical output
@@ -109,7 +109,7 @@ languages in this list are ordered from most relevant as of the latest commit to
 | Risky | https://github.com/RedwolfPrograms/risky | semi-golflang newcomer, with a novel tacit programming approach
 | Floroid | [https://github.com/Yytsi/Floroid](https://github.com/Yytsi/Floroid) | - Python shortened
 | RAD | [https://bitbucket.org/zacharyjtaylor/rad/src/master/](https://bitbucket.org/zacharyjtaylor/rad/src/master/) | Rankless APL
-| arcyou | [https://github.com/nazek42/arcyou](https://github.com/nazek42/arcyou) | Lisp like
+| Arcyóu | [https://github.com/nazek42/arcyou](https://github.com/nazek42/arcyou) | Lisp like
 | TeaScript | [https://github.com/vihanb/TeaScript](https://github.com/vihanb/TeaScript) | JS inspired, not as golfy as japt
 | ESMin | [http://molarmanful.github.io/ESMin](http://molarmanful.github.io/ESMin) | many amazing ideas, but unmaintained
 | Joe | [https://github.com/JaniM/Joe](https://github.com/JaniM/Joe)
@@ -133,7 +133,7 @@ languages in this list are ordered from most relevant as of the latest commit to
 | Name | Link | comments
 |------|------|---------
 | PMA/Snails | [https://github.com/feresum/PMA](https://github.com/feresum/PMA) | Regex like matching on 2D areas
-| The-Language | [https://github.com/m-ender/retina/wiki/The-Language](https://github.com/m-ender/retina/wiki/The-Language) | regex goodness
+| Retina | [https://github.com/m-ender/retina/wiki/The-Language](https://github.com/m-ender/retina/wiki/The-Language) | regex goodness
 | rs | [https://github.com/refi64/rs](https://github.com/refi64/rs) | sed but better
 | grime | [https://github.com/iatorm/grime](https://github.com/iatorm/grime) | 2D pattern matching
 | Slip | [https://github.com/Sp3000/Slip](https://github.com/Sp3000/Slip) | 2D regex
@@ -146,8 +146,8 @@ languages in this list are ordered from most relevant as of the latest commit to
 
 | Name | Link | comments
 |------|------|---------
-| Turtl-d | [https://github.com/Destructible-Watermelon/Turtl-d](https://github.com/Destructible-Watermelon/Turtl-d)
-| noodel/ | [https://tkellehe.github.io/noodel/](https://tkellehe.github.io/noodel/) | ASCII-art animation! (stack based)
+| Turtlèd | [https://github.com/Destructible-Watermelon/Turtl-d](https://github.com/Destructible-Watermelon/Turtl-d)
+| Noodel | [https://tkellehe.github.io/noodel/](https://tkellehe.github.io/noodel/) | ASCII-art animation! (stack based)
 | Canvas | [https://dzaima.github.io/Canvas/?dev](https://dzaima.github.io/Canvas/?dev)
 | V | [https://github.com/DJMcMayhem/V](https://github.com/DJMcMayhem/V) | Vim but basically better
 | autovim | [https://github.com/christianrondeau/autovim](https://github.com/christianrondeau/autovim) | VimScript but better


### PR DESCRIPTION
Particularly Retina, which was previously labeled as The-Language; also smaller fixes to several others.